### PR TITLE
documentation: fix command to check which plugins are embedded

### DIFF
--- a/docs/source/hints.rst
+++ b/docs/source/hints.rst
@@ -46,7 +46,7 @@ plugin packages separately from uWSGI itself).
 In that case you can try to set ``embedded_plugins=False`` for ``PythonSection`` (see Quickstart example).
 
 Another option is to quickly fire up ``uWSGI`` to check what plugins are embedded (the same can be achieved with
-``$ uwsgiconf probe_plugins`` command).
+``$ uwsgiconf probe-plugins`` command).
 
 **uwsgiconf** can also do it for you automatically on configuration stage:
 


### PR DESCRIPTION
Documentation fix: fix command to check which plugins are embedded:

`$ uwsgiconf probe-plugins` instead of `$ uwsgiconf probe_plugins`