### PR TITLE
Resolve Django cache default timeout

### DIFF
--- a/src/uwsgiconf/contrib/django/uwsgify/cache.py
+++ b/src/uwsgiconf/contrib/django/uwsgify/cache.py
@@ -18,13 +18,22 @@ class UwsgiCache(BaseCache):
 
     def __init__(self, name: str, params: dict):
         super().__init__(params)
-        self._cache = _Cache(name)
+        self._cache = _Cache(name, timeout=self._resolve_uwsgi_timeout())
+
+    def _resolve_uwsgi_timeout(self, timeout: object = DEFAULT_TIMEOUT) -> int:
+        if timeout is DEFAULT_TIMEOUT:
+            timeout = self.default_timeout
+
+        if timeout is None:
+            return 0
+
+        return int(timeout)
 
     def _set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
         self._cache.set(
             self.make_and_validate_key(key, version=version),
             pickle.dumps(value),
-            timeout=timeout
+            timeout=self._resolve_uwsgi_timeout(timeout)
         )
 
     def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None) -> bool:

--- a/tests/contrib/django/test_cache.py
+++ b/tests/contrib/django/test_cache.py
@@ -1,3 +1,7 @@
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+
+from uwsgiconf.contrib.django.uwsgify.cache import UwsgiCache
+
 
 def test_cache():
     from django.core.cache import cache
@@ -20,3 +24,16 @@ def test_cache():
 
     cache.clear()
     assert not cache.has_key("some")
+
+
+def test_cache_default_timeout_is_resolved():
+    cache = UwsgiCache("some", {})
+
+    assert cache._resolve_uwsgi_timeout(DEFAULT_TIMEOUT) == 300
+
+
+def test_cache_none_timeout_never_expires():
+    cache = UwsgiCache("some", {"TIMEOUT": None})
+
+    assert cache._resolve_uwsgi_timeout(DEFAULT_TIMEOUT) == 0
+    assert cache._resolve_uwsgi_timeout(None) == 0


### PR DESCRIPTION
## Summary
- Resolve Django's `DEFAULT_TIMEOUT` sentinel before passing timeouts to the uWSGI cache wrapper.
- Preserve Django's configured default timeout, including `TIMEOUT=None` as uWSGI's no-expire value.
- Add regression coverage for omitted and `None` cache timeout settings.

## Testing
- [x] `pytest tests/contrib/django/test_cache.py tests/runtime/test_runtime_caching.py -q`
- [x] `ruff check src tests`
- [x] `pytest tests -q`

Closes #19
