### PR TITLE
feat: add post buffering networking options

### DIFF
--- a/src/uwsgiconf/options/networking.py
+++ b/src/uwsgiconf/options/networking.py
@@ -86,7 +86,9 @@ class Networking(OptionsGroup):
             queue_size: int | None = None,
             freebind: bool | None = None,
             default_socket_type: str | None | type[Socket] = None,
-            buffer_size: int | None = None
+            buffer_size: int | None = None,
+            buffer_post_size: int | None = None,
+            buffer_post_chunk: int | None = None
     ):
         """
 
@@ -119,6 +121,13 @@ class Networking(OptionsGroup):
                 so that "invalid request block size" is logged in your logs you may need to increase it.
                 It is a security measure too, so adapt to your app needs instead of maxing it out.
 
+        :param buffer_post_size:
+            Set the size after which uWSGI buffers HTTP POST data to disk instead of memory
+            (``post-buffering``).
+
+        :param buffer_post_chunk:
+            Set the chunk size used while reading buffered POST data (``post-buffering-bufsize``).
+
         """
         self._set('listen', queue_size)
         self._set('freebind', freebind, cast=bool)
@@ -129,6 +138,8 @@ class Networking(OptionsGroup):
             self._set('socket-protocol', default_socket_type)
 
         self._set('buffer-size', buffer_size)
+        self._set('post-buffering', buffer_post_size)
+        self._set('post-buffering-bufsize', buffer_post_chunk)
 
         return self._section
 

--- a/tests/options/test_networking.py
+++ b/tests/options/test_networking.py
@@ -10,8 +10,16 @@ def test_networking_basics(assert_lines):
     assert_lines([
         'listen = 3',
         'buffer-size = 65535',
+        'post-buffering = 65536',
+        'post-buffering-bufsize = 8192',
         'socket-protocol = raw',
-    ], net.set_basic_params(queue_size=3, buffer_size=65535, default_socket_type=net.sockets.raw))
+    ], net.set_basic_params(
+        queue_size=3,
+        buffer_size=65535,
+        buffer_post_size=65536,
+        buffer_post_chunk=8192,
+        default_socket_type=net.sockets.raw,
+    ))
 
     assert_lines([
         'so-keepalive = true',


### PR DESCRIPTION
## Summary

- Add native `buffer_post_size` and `buffer_post_chunk` parameters to `Networking.set_basic_params`.
- Map the new parameters to uWSGI `post-buffering` and `post-buffering-bufsize` options, with regression coverage in the networking option tests.

## Test plan

- [x] `uv run ruff check src/uwsgiconf/options/networking.py tests/options/test_networking.py`
- [x] `uv run python -m pytest tests/options/test_networking.py -q`
- [x] `uv run python -m pytest tests/options -q`

Closes #21
